### PR TITLE
Add Windows coverage via OpenCppCoverage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
       shell: bash
       run: |
         set -x
-        cmake -G Ninja -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=ON -DENABLE_COVERAGE:BOOL=ON ../
+        cmake -G Ninja -DCMAKE_BUILD_TYPE:STRING=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=ON -DENABLE_COVERAGE:BOOL=ON ../
 
     - name: Build
       working-directory: ./build

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -24,7 +24,7 @@ jobs:
       with:
         python-version: '3.9'
 
-    - name: Install conan
+    - name: Install conan and openccpcoverage
       run: |
           python --version
           pip install conan gcovr
@@ -33,27 +33,47 @@ jobs:
           conan config set general.revisions_enabled=True
           conan config set general.parallel_download=8
           conan user
-          mkdir build
+
+
+    - name: Install deps
+      run: |
+        mkdir build
+        echo "Using chocolatey to install OpenCppCoverage"
+        choco install opencppcoverage
+        echo "Using chocolatey to install ninja"
+        choco install ninja
+
+        # C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise
+        MSVC_DIR=$(cmd.exe /c "vswhere -products * -requires Microsoft.Component.MSBuild -property installationPath -latest")
+        echo "Latest is: $MSVC_DIR"
+        echo "MSVC_DIR=$MSVC_DIR" >> $GITHUB_ENV
+        # add folder containing vcvarsall.bat
+        echo "$MSVC_DIR\VC\Auxiliary\Build" >> $GITHUB_PATH
 
     - name: CMake configure
       working-directory: ./build
+      shell: cmd
       run: |
-        cmake -G "Visual Studio 16 2019" -A x64 -T ClangCL -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=ON -DENABLE_COVERAGE:BOOL=ON ../
+        echo "Using vcvarsall to initialize the development environment"
+        call vcvarsall.bat x64
+        cmake -G Ninja -DCMAKE_BUILD_TYPE:STRING=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=ON -DENABLE_COVERAGE:BOOL=ON ../
 
     - name: Build
       working-directory: ./build
       run: |
-        cmake --build . -j 2 --config ${{ env.BUILD_TYPE }}
+        ninja
 
     - name: Produce coverage report
       working-directory: ./build
       shell: bash
       run: |
         set -x
-        ./Products/testlib_tests
+        OpenCppCoverage --sources ../* ./Products/testlib_tests
         gcovr -j $(nproc) --delete --root ../ --exclude '.*GTest.cpp' --xml-pretty --xml coverage.xml .
 
     - name: Publish to codecov
       uses: codecov/codecov-action@v2
       with:
+        flags: ${{ runner.os }}
+        name: ${{ runner.os }}-coverage
         files: ./build/coverage.xml

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -1,0 +1,59 @@
+name: C++ CI Windows Clang
+
+on:
+  push:
+    branches: [ main, Windows ]
+    # Sequence of patterns matched against refs/tags
+    tags:
+      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+  pull_request:
+    branches: [ main ]
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Debug
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.9'
+
+    - name: Install conan
+      run: |
+          python --version
+          pip install conan gcovr
+          conan --version
+          echo "Enabling conan revisions and setting parallel_download"
+          conan config set general.revisions_enabled=True
+          conan config set general.parallel_download=8
+          conan user
+          mkdir build
+
+    - name: CMake configure
+      working-directory: ./build
+      run: |
+        cmake -G "Visual Studio 16 2019" -A x64 -T ClangCL -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=ON -DENABLE_COVERAGE:BOOL=ON ../
+
+    - name: Build
+      working-directory: ./build
+      run: |
+        cmake --build . -j 2 --config ${{ env.BUILD_TYPE }}
+
+    - name: Produce coverage report
+      working-directory: ./build
+      shell: bash
+      run: |
+        set -x
+        ./Products/testlib_tests
+        gcovr -j $(nproc) --delete --root ../ --exclude '.*GTest.cpp' --xml-pretty --xml coverage.xml .
+
+    - name: Publish to codecov
+      uses: codecov/codecov-action@v2
+      with:
+        files: ./build/coverage.xml

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -24,7 +24,7 @@ jobs:
       with:
         python-version: '3.9'
 
-    - name: Install conan and openccpcoverage
+    - name: Install conan
       run: |
           python --version
           pip install conan gcovr
@@ -36,6 +36,7 @@ jobs:
 
 
     - name: Install deps
+      shell: bash
       run: |
         mkdir build
         echo "Using chocolatey to install OpenCppCoverage"
@@ -56,7 +57,7 @@ jobs:
       run: |
         echo "Using vcvarsall to initialize the development environment"
         call vcvarsall.bat x64
-        cmake -G Ninja -DCMAKE_BUILD_TYPE:STRING=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=ON -DENABLE_COVERAGE:BOOL=ON ../
+        cmake -G Ninja -DCMAKE_BUILD_TYPE:STRING=Debug -DENABLE_COVERAGE:BOOL=ON ../
 
     - name: Build
       working-directory: ./build
@@ -65,11 +66,8 @@ jobs:
 
     - name: Produce coverage report
       working-directory: ./build
-      shell: bash
       run: |
-        set -x
-        OpenCppCoverage --sources ../* ./Products/testlib_tests
-        gcovr -j $(nproc) --delete --root ../ --exclude '.*GTest.cpp' --xml-pretty --xml coverage.xml .
+        OpenCppCoverage.exe --sources TestCpp-GHA-Coverage\src --export_type cobertura:coverage.xml -- Products\testlib_tests.exe
 
     - name: Publish to codecov
       uses: codecov/codecov-action@v2

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -1,4 +1,4 @@
-name: C++ CI Windows Clang
+name: C++ CI Windows
 
 on:
   push:

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -41,6 +41,8 @@ jobs:
         mkdir build
         echo "Using chocolatey to install OpenCppCoverage"
         choco install opencppcoverage
+        echo "C:/Program Files/OpenCppCoverage" >> $GITHUB_PATH
+
         echo "Using chocolatey to install ninja"
         choco install ninja
 

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -51,17 +51,15 @@ jobs:
         # add folder containing vcvarsall.bat
         echo "$MSVC_DIR\VC\Auxiliary\Build" >> $GITHUB_PATH
 
-    - name: CMake configure
+    - name: CMake configure & build
       working-directory: ./build
       shell: cmd
       run: |
         echo "Using vcvarsall to initialize the development environment"
         call vcvarsall.bat x64
-        cmake -G Ninja -DCMAKE_BUILD_TYPE:STRING=Debug -DENABLE_COVERAGE:BOOL=ON ../
-
-    - name: Build
-      working-directory: ./build
-      run: |
+        # Note ENABLE_COVERAGE isn't an option on MSVC, it works differently
+        cmake -G Ninja -DCMAKE_BUILD_TYPE:STRING=Debug ../
+        # We need vcvarsall.bat to be called in the current step where ninja is invoked, so do that here as well
         ninja
 
     - name: Produce coverage report

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -2,7 +2,7 @@ name: C++ CI Windows
 
 on:
   push:
-    branches: [ main, Windows ]
+    branches: [ main ]
     # Sequence of patterns matched against refs/tags
     tags:
       - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,8 @@ else()
 endif()
 
 # Enable runtime checking features: TSAN, ASAN, UBSAN
-if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
+message("CMAKE_CXX_COMPILER_ID=${CMAKE_CXX_COMPILER_ID}")
+if(CMAKE_COMPILER_IS_GNUCC OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
 
   option(ENABLE_COVERAGE "Enable coverage reporting for gcc/clang" ON)
   if(ENABLE_COVERAGE)

--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ There is also a [clang-format action](.github/workflows/clang-format-check.yml) 
 
 `Person.cpp` has a few compiler specific macros, so that we can test merging reports from several platforms on codecov. See [src/Person.cpp#L18-L27](https://github.com/jmarrec/TestCpp-GHA-Coverage/blob/408d98bb68b05222006d052dd6367090827ed8fc/src/Person.cpp#L18-L27)
 
+
+See [PR#5](https://github.com/jmarrec/TestCpp-GHA-Coverage/pull/5) for more info including before/after screenshots when I added Mac in addition to Ubuntu
+
 ![Mac+Ubuntu](https://user-images.githubusercontent.com/5479063/131817697-44e8ac87-577e-4531-9bf5-fd05a07bba28.png)
 
-See [PR#5](https://github.com/jmarrec/TestCpp-GHA-Coverage/pull/5) for more info including before/after screenshots
+
+See [PR#6](https://github.com/jmarrec/TestCpp-GHA-Coverage/pull/6) when I added Windows (via OpenCppCoverage) in addition to Mac and Ubuntu. **Looks like Windows's report don't merge correctly to codecov?**
+
+![image](https://user-images.githubusercontent.com/5479063/131827053-6bff2bdf-ed92-4ddc-aa5a-efcaed3c3220.png)
+
+**Note: Looks like there is a viewing problem where the clang line is no longer green, yet report is correctly at 100%**

--- a/src/Person.cpp
+++ b/src/Person.cpp
@@ -20,7 +20,7 @@ bool Person::setName(const std::string& t_newName) {
     fmt::print("Clang: {} was rejected by the government\n", t_newName);
 #elif __GNUC__
     fmt::print("GCC: {} was rejected by the government\n", t_newName);
-#elif __MSC_VER
+#elif _MSC_VER
     fmt::print("MSVC: {} was rejected by the government\n", t_newName);
 #endif
     return false;


### PR DESCRIPTION
# Ubuntu Only

Before with Ubuntu only on main: https://codecov.io/gh/jmarrec/TestCpp-GHA-Coverage/src/408d98bb68b05222006d052dd6367090827ed8fc/src/Person.cpp 

![image](https://user-images.githubusercontent.com/5479063/131817628-7230881a-adc4-4e70-a07d-48ae6838bae9.png)

# Ubuntu + Mac

After PR #5: https://codecov.io/gh/jmarrec/TestCpp-GHA-Coverage/src/245baf4526175397e872ebc8aa9ba05a9c7e3b9f/src/Person.cpp

![image](https://user-images.githubusercontent.com/5479063/131817697-44e8ac87-577e-4531-9bf5-fd05a07bba28.png)

# Ubuntu + Mac + Windows (#6)

See now: https://app.codecov.io/gh/jmarrec/TestCpp-GHA-Coverage/blob/409e3547cb629dd524879e13c46029a4075857e3/src/Person.cpp

![image](https://user-images.githubusercontent.com/5479063/131827053-6bff2bdf-ed92-4ddc-aa5a-efcaed3c3220.png)


**Looks like there is a viewing problem where the clang line is no longer green, yet report is 100%**